### PR TITLE
chore: ignore development-notes/ in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@
 /coverage
 /dist
 node_modules
+development-notes/


### PR DESCRIPTION
add a rule for .prettoerignore to ignore development-notes in prettier