### PR TITLE
refactor: change base `href` attribute in `index.html`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>RS Tandem</title>
-    <base href="/" />
+    <base href="./" />
     <meta content="width=device-width, initial-scale=1" name="viewport" />
     <link href="favicon.ico" rel="icon" type="image/x-icon" />
   </head>


### PR DESCRIPTION
The problem:
`<base href="/">` in `index.html` makes Angular treat the app as if it’s hosted at the domain root, not under `/Rs-Tandem/`.
Therefore, routing in file `app.routes.ts` to `/async-sorter-or-any-other-route` doesn't work.