### PR TITLE
fix: replace wrong text

### DIFF
--- a/src/app/pages/games/async-sorter/components/mistakes-counter/mistakes-counter.html
+++ b/src/app/pages/games/async-sorter/components/mistakes-counter/mistakes-counter.html
@@ -1,1 +1,1 @@
-<p>{{ 'asyncSorter.finalCallStack' | transloco }} {{ mistakes() }}</p>
+<p>{{ 'asyncSorter.wrongMoves' | transloco }} {{ mistakes() }}</p>


### PR DESCRIPTION
Before: 
<img width="779" height="188" alt="Screenshot 2026-04-18 165644" src="https://github.com/user-attachments/assets/1bc83ca1-d04f-463f-b226-ef07436612db" />  

After: 
<img width="756" height="192" alt="Screenshot 2026-04-18 165625" src="https://github.com/user-attachments/assets/38316d5b-9bae-4bec-aded-ab087e2dffe8" />
